### PR TITLE
Fix tags migration default and add DAO tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,6 +99,9 @@ dependencies {
     
     // Testing
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.11.1")
+    testImplementation("androidx.test:core:1.5.0")
+    testImplementation("androidx.room:room-testing:2.6.1")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2024.02.00"))

--- a/app/src/main/java/de/thnuernberg/bme/geheimzentrale/data/local/AppDatabase.kt
+++ b/app/src/main/java/de/thnuernberg/bme/geheimzentrale/data/local/AppDatabase.kt
@@ -17,7 +17,7 @@ import de.thnuernberg.bme.geheimzentrale.data.model.PlaylistEpisode
         PlaylistEpisode::class,
         EpisodeStatus::class
     ],
-    version = 2,
+    version = 3,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -27,7 +27,13 @@ abstract class AppDatabase : RoomDatabase() {
     companion object {
         private val MIGRATION_1_2 = object : Migration(1, 2) {
             override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("ALTER TABLE episode_status ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'")
+                database.execSQL("ALTER TABLE episode_status ADD COLUMN tags TEXT NOT NULL DEFAULT ''")
+            }
+        }
+
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("UPDATE episode_status SET tags = '' WHERE tags = '[]'")
             }
         }
 
@@ -41,7 +47,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "geheimzentrale.db"
                 )
-                .addMigrations(MIGRATION_1_2)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                 .build()
                 INSTANCE = instance
                 instance

--- a/app/src/test/java/de/thnuernberg/bme/geheimzentrale/data/local/PlaylistDaoTest.kt
+++ b/app/src/test/java/de/thnuernberg/bme/geheimzentrale/data/local/PlaylistDaoTest.kt
@@ -1,0 +1,45 @@
+package de.thnuernberg.bme.geheimzentrale.data.local
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class PlaylistDaoTest {
+    private lateinit var db: AppDatabase
+    private lateinit var dao: PlaylistDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.playlistDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun tagsRoundTrip() = runBlocking {
+        val status = EpisodeStatus(episodeId = 1, tags = listOf("a", "b"))
+        dao.updateEpisodeStatus(status)
+        val loaded = dao.getEpisodeStatus(1)
+        assertEquals(listOf("a", "b"), loaded?.tags)
+    }
+
+    @Test
+    fun emptyTagsRoundTrip() = runBlocking {
+        val status = EpisodeStatus(episodeId = 2)
+        dao.updateEpisodeStatus(status)
+        val loaded = dao.getEpisodeStatus(2)
+        assertEquals(emptyList<String>(), loaded?.tags)
+    }
+}


### PR DESCRIPTION
## Summary
- default `tags` column to empty string
- add migration updating old `'[]'` values
- include new dependencies for DAO tests
- test playlist DAO round-trip of tag lists

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684be187ce5483318acd591e220a1f90