### PR TITLE
Fix duplicate migration object

### DIFF
--- a/app/src/main/java/de/thnuernberg/bme/geheimzentrale/data/local/AppDatabase.kt
+++ b/app/src/main/java/de/thnuernberg/bme/geheimzentrale/data/local/AppDatabase.kt
@@ -17,7 +17,7 @@ import de.thnuernberg.bme.geheimzentrale.data.model.PlaylistEpisode
         PlaylistEpisode::class,
         EpisodeStatus::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -37,7 +37,7 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
-        private val MIGRATION_2_3 = object : Migration(2, 3) {
+        private val MIGRATION_3_4 = object : Migration(3, 4) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE episode_status ADD COLUMN isFavorite INTEGER NOT NULL DEFAULT 0")
             }
@@ -53,7 +53,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "geheimzentrale.db"
                 )
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
                 .build()
                 INSTANCE = instance
                 instance


### PR DESCRIPTION
## Summary
- fix duplicate `MIGRATION_2_3` definition
- bump database version to 4
- register new migration in `addMigrations`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684be6581f0c8331a6c5d81ca3a84ce0