### PR TITLE
Update Kotlin compiler to 1.9.22

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.0"
+        kotlinCompilerExtensionVersion = "1.5.11"
     }
     packaging {
         resources {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.9.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
     id("org.jetbrains.compose") version "1.5.11" apply false
     id("com.google.dagger.hilt.android") version "2.48" apply false
 }
@@ -13,6 +13,6 @@ buildscript {
     }
     dependencies {
         classpath("com.google.dagger:hilt-android-gradle-plugin:2.48")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
     }
 }


### PR DESCRIPTION
## Summary
- bump `org.jetbrains.kotlin.android` plugin and kotlin classpath to 1.9.22
- set compose `kotlinCompilerExtensionVersion` to 1.5.11

## Testing
- `./gradlew clean assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684be6459bc88331a73c894a84a4d064