### PR TITLE
Fix migration numbering and add migration test

### DIFF
--- a/app/src/main/java/de/thnuernberg/bme/geheimzentrale/data/local/AppDatabase.kt
+++ b/app/src/main/java/de/thnuernberg/bme/geheimzentrale/data/local/AppDatabase.kt
@@ -17,7 +17,7 @@ import de.thnuernberg.bme.geheimzentrale.data.model.PlaylistEpisode
         PlaylistEpisode::class,
         EpisodeStatus::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -37,7 +37,7 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
-        private val MIGRATION_2_3 = object : Migration(2, 3) {
+        private val MIGRATION_3_4 = object : Migration(3, 4) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE episode_status ADD COLUMN isFavorite INTEGER NOT NULL DEFAULT 0")
             }
@@ -53,7 +53,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "geheimzentrale.db"
                 )
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
                 .build()
                 INSTANCE = instance
                 instance

--- a/app/src/test/java/de/thnuernberg/bme/geheimzentrale/data/local/AppDatabaseMigrationTest.kt
+++ b/app/src/test/java/de/thnuernberg/bme/geheimzentrale/data/local/AppDatabaseMigrationTest.kt
@@ -1,0 +1,61 @@
+import android.content.Context
+import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.room.testing.MigrationTestHelper
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AppDatabaseMigrationTest {
+    private val TEST_DB = "migration-test"
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDatabase::class.java.canonicalName,
+        FrameworkSQLiteOpenHelperFactory()
+    )
+
+    private fun migration(name: String): Migration {
+        val field = AppDatabase::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        return field.get(null) as Migration
+    }
+
+    @Test
+    fun migrateAll() {
+        helper.createDatabase(TEST_DB, 1).apply {
+            execSQL("CREATE TABLE IF NOT EXISTS `playlists` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `createdAt` INTEGER NOT NULL)")
+            execSQL("CREATE TABLE IF NOT EXISTS `playlist_episodes` (`playlistId` INTEGER NOT NULL, `episodeId` INTEGER NOT NULL, `position` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `episodeId`))")
+            execSQL("CREATE TABLE IF NOT EXISTS `episode_status` (`episodeId` INTEGER PRIMARY KEY NOT NULL, `isListened` INTEGER NOT NULL, `isInProgress` INTEGER NOT NULL, `progress` INTEGER NOT NULL, `lastUpdated` INTEGER NOT NULL)")
+            close()
+        }
+
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val db = Room.databaseBuilder(context, AppDatabase::class.java, TEST_DB)
+            .addMigrations(
+                migration("MIGRATION_1_2"),
+                migration("MIGRATION_2_3"),
+                migration("MIGRATION_3_4")
+            )
+            .build()
+
+        db.query("SELECT * FROM episode_status", emptyArray()).close()
+        db.query("PRAGMA table_info(`episode_status`)", emptyArray()).use { cursor ->
+            var found = false
+            while (cursor.moveToNext()) {
+                if (cursor.getString(cursor.getColumnIndexOrThrow("name")) == "isFavorite") {
+                    found = true
+                }
+            }
+            assertTrue(found)
+        }
+        db.close()
+    }
+}


### PR DESCRIPTION
## Summary
- add unique migration `MIGRATION_3_4`
- bump `AppDatabase` version to 4
- register all migrations when building the DB
- add unit test verifying migrations run correctly

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684be6269b588331bb2c1e910c8b3c1b