### PR TITLE
Add Gson mapping and Episode tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,6 +96,9 @@ dependencies {
     
     // Coil
     implementation("io.coil-kt:coil-compose:2.5.0")
+
+    // JSON
+    implementation("com.google.code.gson:gson:2.10.1")
     
     // Testing
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/de/thnuernberg/bme/geheimzentrale/data/model/EpisodeDto.kt
+++ b/app/src/main/java/de/thnuernberg/bme/geheimzentrale/data/model/EpisodeDto.kt
@@ -1,0 +1,30 @@
+package de.thnuernberg.bme.geheimzentrale.data.model
+
+import com.google.gson.annotations.SerializedName
+import java.time.LocalDate
+
+/**
+ * DTOs mirroring the structure of the episode JSON file.
+ */
+
+data class ApiResponseDto(
+    val dbInfo: DbInfo,
+    val serie: List<EpisodeDto>
+)
+
+/** Episode structure as stored in the JSON file */
+data class EpisodeDto(
+    val nummer: Int,
+    val titel: String,
+    val autor: String,
+    val hörspielskriptautor: String,
+    val gesamtbeschreibung: String,
+    val beschreibung: String,
+    @SerializedName("veröffentlichungsdatum")
+    val veroeffentlichungsdatum: LocalDate,
+    val kapitel: List<Kapitel>,
+    val sprechrollen: List<Sprechrolle>,
+    val links: Links,
+    val ids: Ids,
+    val medien: List<Medium>
+)

--- a/app/src/main/java/de/thnuernberg/bme/geheimzentrale/data/model/EpisodeMapper.kt
+++ b/app/src/main/java/de/thnuernberg/bme/geheimzentrale/data/model/EpisodeMapper.kt
@@ -1,0 +1,38 @@
+package de.thnuernberg.bme.geheimzentrale.data.model
+
+import javax.inject.Inject
+
+/** Maps [EpisodeDto] objects to domain [Episode] instances. */
+class EpisodeMapper @Inject constructor() {
+    fun fromDto(dto: EpisodeDto): Episode {
+        val durationMs = dto.medien
+            .flatMap { it.tracks }
+            .sumOf { it.end - it.start }
+        val coverUrl = when {
+            dto.links.cover.isNotEmpty() -> dto.links.cover
+            dto.links.cover_kosmos.isNotEmpty() -> dto.links.cover_kosmos
+            else -> dto.links.cover_itunes
+        }
+        val sprecher = dto.sprechrollen.map { it.sprecher }
+        return Episode(
+            nummer = dto.nummer,
+            titel = dto.titel,
+            autor = dto.autor,
+            hörspielskriptautor = dto.hörspielskriptautor,
+            gesamtbeschreibung = dto.gesamtbeschreibung,
+            beschreibung = dto.beschreibung,
+            veröffentlichungsdatum = dto.veroeffentlichungsdatum.toString(),
+            kapitel = dto.kapitel,
+            sprechrollen = dto.sprechrollen,
+            links = dto.links,
+            ids = dto.ids,
+            medien = dto.medien,
+            erscheinungsdatum = dto.veroeffentlichungsdatum,
+            dauer = (durationMs / 1000),
+            coverUrl = coverUrl,
+            sprecher = sprecher
+        )
+    }
+
+    fun fromDtoList(list: List<EpisodeDto>): List<Episode> = list.map { fromDto(it) }
+}

--- a/app/src/main/java/de/thnuernberg/bme/geheimzentrale/di/AppModule.kt
+++ b/app/src/main/java/de/thnuernberg/bme/geheimzentrale/di/AppModule.kt
@@ -2,6 +2,8 @@ package de.thnuernberg.bme.geheimzentrale.di
 
 import android.content.Context
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonDeserializer
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -10,6 +12,7 @@ import dagger.hilt.components.SingletonComponent
 import de.thnuernberg.bme.geheimzentrale.data.api.DreiFragezeichenApi
 import de.thnuernberg.bme.geheimzentrale.data.local.PlaylistDao
 import de.thnuernberg.bme.geheimzentrale.data.repository.DreiFragezeichenRepository
+import de.thnuernberg.bme.geheimzentrale.data.model.EpisodeMapper
 import javax.inject.Singleton
 
 @Module
@@ -18,14 +21,20 @@ object AppModule {
     
     @Provides
     @Singleton
-    fun provideGson(): Gson = Gson()
+    fun provideGson(): Gson = GsonBuilder()
+        .registerTypeAdapter(
+            java.time.LocalDate::class.java,
+            JsonDeserializer { json, _, _ -> java.time.LocalDate.parse(json.asString) }
+        )
+        .create()
 
     @Provides
     @Singleton
     fun provideLocalJsonReader(
         @ApplicationContext context: Context,
-        gson: Gson
-    ): LocalJsonReader = LocalJsonReader(context, gson)
+        gson: Gson,
+        episodeMapper: EpisodeMapper
+    ): LocalJsonReader = LocalJsonReader(context, gson, episodeMapper)
 
     @Provides
     @Singleton

--- a/app/src/main/java/de/thnuernberg/bme/geheimzentrale/di/NetworkModule.kt
+++ b/app/src/main/java/de/thnuernberg/bme/geheimzentrale/di/NetworkModule.kt
@@ -3,8 +3,9 @@ package de.thnuernberg.bme.geheimzentrale.di
 import android.content.Context
 import com.google.gson.Gson
 import de.thnuernberg.bme.geheimzentrale.data.api.DreiFragezeichenApi
-import de.thnuernberg.bme.geheimzentrale.data.model.ApiResponse
+import de.thnuernberg.bme.geheimzentrale.data.model.ApiResponseDto
 import de.thnuernberg.bme.geheimzentrale.data.model.Episode
+import de.thnuernberg.bme.geheimzentrale.data.model.EpisodeMapper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.IOException
@@ -14,13 +15,14 @@ import javax.inject.Singleton
 @Singleton
 class LocalJsonReader @Inject constructor(
     private val context: Context,
-    private val gson: Gson
+    private val gson: Gson,
+    private val episodeMapper: EpisodeMapper
 ) {
     suspend fun readEpisoden(): List<Episode> = withContext(Dispatchers.IO) {
         try {
             val jsonString = context.assets.open("episodes.json").bufferedReader().use { it.readText() }
-            val response: ApiResponse = gson.fromJson(jsonString, ApiResponse::class.java)
-            response.serie
+            val response: ApiResponseDto = gson.fromJson(jsonString, ApiResponseDto::class.java)
+            episodeMapper.fromDtoList(response.serie)
         } catch (e: IOException) {
             emptyList()
         }

--- a/app/src/test/assets/episodes.json
+++ b/app/src/test/assets/episodes.json
@@ -1,0 +1,39 @@
+{
+  "dbInfo": {
+    "version": "1",
+    "lastModified": "2024-01-01T00:00:00Z"
+  },
+  "serie": [
+    {
+      "nummer": 1,
+      "titel": "Die Probe",
+      "autor": "Testautor",
+      "hörspielskriptautor": "Skript",
+      "gesamtbeschreibung": "GB",
+      "beschreibung": "B",
+      "veröffentlichungsdatum": "2020-02-20",
+      "kapitel": [],
+      "sprechrollen": [
+        {"rolle": "A", "sprecher": "S1"},
+        {"rolle": "B", "sprecher": "S2"}
+      ],
+      "links": {
+        "json": "",
+        "ffmetadata": "",
+        "cover": "cover.png",
+        "cover_itunes": "it.png",
+        "cover_kosmos": "ko.png",
+        "dreifragezeichen": ""
+      },
+      "ids": {"dreimetadaten": 1},
+      "medien": [
+        {
+          "tracks": [
+            {"titel": "t1", "start": 0, "end": 1000},
+            {"titel": "t2", "start": 1000, "end": 3000}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/app/src/test/java/de/thnuernberg/bme/geheimzentrale/di/LocalJsonReaderTest.kt
+++ b/app/src/test/java/de/thnuernberg/bme/geheimzentrale/di/LocalJsonReaderTest.kt
@@ -1,0 +1,29 @@
+package de.thnuernberg.bme.geheimzentrale.di
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import de.thnuernberg.bme.geheimzentrale.data.model.EpisodeMapper
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LocalJsonReaderTest {
+    @Test
+    fun readEpisodeFromJson() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val gson = AppModule.provideGson()
+        val mapper = EpisodeMapper()
+        val reader = LocalJsonReader(context, gson, mapper)
+
+        val episodes = reader.readEpisoden()
+        assertEquals(1, episodes.size)
+        val episode = episodes.first()
+
+        assertEquals(1, episode.nummer)
+        assertEquals("Die Probe", episode.titel)
+        assertEquals("Testautor", episode.autor)
+        assertEquals(listOf("S1", "S2"), episode.sprecher)
+        assertEquals(3, episode.dauer)
+        assertEquals("cover.png", episode.coverUrl)
+    }
+}


### PR DESCRIPTION
## Summary
- add Gson dependency
- configure custom Gson deserializer for `LocalDate`
- create DTO and mapper for episodes
- parse episodes from JSON using mapper
- test `LocalJsonReader` with sample JSON

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684be625447c8331a8477d9f0f2fb013